### PR TITLE
feat: Update README date daily with day, month, and year

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -3,7 +3,7 @@ name: Weekly Update README
 on:
   # Run every Sunday at 00:00 UTC
   schedule:
-    - cron: "0 0 * * 0"
+    - cron: "0 0 * * *"
   # Allows you to run this workflow manually from GitHub Actions tab
   workflow_dispatch:
 
@@ -24,5 +24,5 @@ jobs:
           git config user.name "github-actions"
           git config user.email "actions@github.com"
           git add README.md
-          git commit -m "Automated monthly/year update in README [skip ci]" || echo "No changes to commit"
+          git commit -m "Automated daily date update in README [skip ci]" || echo "No changes to commit"
           git push

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <strong>Notice Board:</strong> IDM trial reset tool is working 100%! You can easily use it from our Telegram bot: <a href="https://t.me/IDMTrialResetBot" target="_blank">@IDMTrialResetBot</a>
 </div>
 
-# IDM Trial Reset Tool (v6.42 Build 24) - January 2025
+# IDM Trial Reset Tool (v6.42 Build 24) - 05 June 2025
 
 The **IDM Trial Reset Tool** is a powerful utility designed for educational and informational purposes, allowing users to **reset the trial period of Internet Download Manager (IDM)**. This tool helps **extend the IDM trial period** without violating any software cracking practices, making it a great solution for users who want to evaluate IDM over an extended time before committing to a purchase. Remember, using this tool should comply with legal standards, and the best way to support IDM is by purchasing a license once you've decided on its long-term use.
 

--- a/update_readme.py
+++ b/update_readme.py
@@ -8,12 +8,12 @@ with open("README.md", "r", encoding="utf-8") as f:
     content = f.read()
 
 # Construct the new month-year string, e.g. "February 2025"
-current_date_str = datetime.now().strftime("%B %Y")
+current_date_str = datetime.now().strftime("%d %B %Y")
 
 # Regex pattern to match something like:
 # "# IDM Trial Reset Tool (v6.42 Build 23) - January 2025"
-pattern = r"(# IDM Trial Reset Tool \(v\d+\.\d+ Build \d+\) - )([A-Za-z]+\s+\d{4})"
-replacement = r"\1" + current_date_str
+pattern = r"(# IDM Trial Reset Tool \(v\d+\.\d+ Build \d+\) - )(\d*\s*[A-Za-z]+\s+\d{4})"
+replacement = r"\g<1>" + current_date_str
 
 new_content = re.sub(pattern, replacement, content)
 


### PR DESCRIPTION
Modifies `update_readme.py` to include the day in the date string (e.g., "05 June 2025") and updates the regex to correctly replace the date in the main heading of `README.md`.

Updates the `.github/workflows/update-readme.yml` GitHub Actions workflow to run daily (00:00 UTC) instead of weekly. The commit message within the workflow has also been generalized.

A regex replacement issue in `update_readme.py` (using `` vs `\g<1>`) was identified and corrected during testing.